### PR TITLE
Fixed the Segmentation fault during generating tfrecord for RNet and ONet

### DIFF
--- a/prepare_data/gen_ONet_tfrecords.py
+++ b/prepare_data/gen_ONet_tfrecords.py
@@ -63,7 +63,6 @@ def run(dataset_dir, net, output_dir, name='MTCNN', shuffling=False):
             sys.stdout.flush()
             filename = image_example['filename']
             _add_to_tfrecord(filename, image_example, tfrecord_writer)
-    tfrecord_writer.close()
     # Finally, write the labels file:
     # labels_to_class_names = dict(zip(range(len(_CLASS_NAMES)), _CLASS_NAMES))
     # dataset_utils.write_label_file(labels_to_class_names, dataset_dir)

--- a/prepare_data/gen_RNet_tfrecords.py
+++ b/prepare_data/gen_RNet_tfrecords.py
@@ -63,7 +63,6 @@ def run(dataset_dir, net, output_dir, name='MTCNN', shuffling=False):
             sys.stdout.flush()
             filename = image_example['filename']
             _add_to_tfrecord(filename, image_example, tfrecord_writer)
-    tfrecord_writer.close()
     # Finally, write the labels file:
     # labels_to_class_names = dict(zip(range(len(_CLASS_NAMES)), _CLASS_NAMES))
     # dataset_utils.write_label_file(labels_to_class_names, dataset_dir)


### PR DESCRIPTION
Fixed the small bug, tfrecord_writer used python "with" statement, tfrecord_writer will be closed automatically and released itself. when we try to close it again, it will be a segmentation fault since it has been released.