### PR TITLE
set the image_size accordingly to the provided flag for test_mode

### DIFF
--- a/prepare_data/gen_hard_example.py
+++ b/prepare_data/gen_hard_example.py
@@ -212,27 +212,25 @@ def parse_args():
 
 if __name__ == '__main__':
 
-    net = 'ONet'
-    if net == "RNet":
+    args = parse_args()
+
+    print 'Called with argument:'
+    print args
+
+    if args.test_mode == "PNet":
         image_size = 24
-    if net == "ONet":
+    if args.test_mode in ["RNet", "ONet"]:
         image_size = 48
 
-    base_dir = '../prepare_data/WIDER_train'
     data_dir = '%s' % str(image_size)
     
     neg_dir = get_path(data_dir, 'negative')
     pos_dir = get_path(data_dir, 'positive')
     part_dir = get_path(data_dir, 'part')
-    #create dictionary shuffle   
     for dir_path in [neg_dir, pos_dir, part_dir]:
         if not os.path.exists(dir_path):
             os.makedirs(dir_path)
 
-    args = parse_args()
-
-    print 'Called with argument:'
-    print args 
     t_net(args.prefix,#model param's file
           args.epoch, #final epoches
           args.batch_size, #test batch_size 


### PR DESCRIPTION
Previously we had to set the variable manually for PNet or RNet to set the image_size. This minor fix sets the image accordingly to the given flag for test_mode.

If the flag is "PNet" the image_size is set to 24 and for the other two "RNet" and "ONet", the image_size is 48, As PNet model generates hard examples for RNet and so on.